### PR TITLE
Run script only on DuoLingo

### DIFF
--- a/duolingo-course-switcher.user.js
+++ b/duolingo-course-switcher.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        DuoLingo Course Switcher
 // @namespace   http://moviemap.me/duoinc
-// @include     *
+// @include     https://www.duolingo.com/*
 // @downloadURL https://github.com/mofman/DuolingoCourseSwitcher/raw/master/duolingo-course-switcher.user.js
 // @updateURL   https://github.com/mofman/DuolingoCourseSwitcher/raw/master/duolingo-course-switcher.user.js
 // @version     0.5.2


### PR DESCRIPTION
Currently this will try to run on every page of every site I visit, usually throwing an error about jQuery's $ variable not being defined. This is a quick fix to limit its scope to DuoLingo. Thanks!